### PR TITLE
Fix: markdown version 3.0 positional arguments deprecated

### DIFF
--- a/core/utils/report.py
+++ b/core/utils/report.py
@@ -1,6 +1,7 @@
 # -*- coding: utf8 -*-
 import logging
-from markdown import markdownFromFile
+import codecs
+from markdown import markdown
 from os.path import abspath, exists, join
 from weasyprint import HTML
 
@@ -24,7 +25,9 @@ def generate_report(path, theme=None, intype='md'):
     """
     assert intype in ['html', 'md']
     if intype == 'md':
-        html = markdownFromFile(join(path, 'report.md'))
+        input_file = codecs.open(join(path, 'report.md'), mode="r", encoding="utf-8")
+        text = input_file.read()
+        html = markdown(text)
     else:
         html = open(join(path, 'report.html')).read()
     html = HTML(string=html, base_url='file://{}/'.format(abspath(path)))


### PR DESCRIPTION
Hi @dhondta, great project, thank you!

I ran into a couple of problems generating the reports with the latest version of markdown:

- python-markdown no longer allows positional arguments on the markdown() for markdownFromFile() functions:  [](https://python-markdown.github.io/change_log/release-3.0/)

- Furthermore, the output options in markdownFromFile() have been restricted.  